### PR TITLE
Add nanomatch.capture to return captured matches

### DIFF
--- a/index.js
+++ b/index.js
@@ -535,6 +535,44 @@ nanomatch.matcher = function matcher(pattern, options) {
 };
 
 /**
+ * Returns an array of matches captured by `pattern` in `string, or `null` if the pattern did not match.
+ *
+ * ```js
+ * var nm = require('nanomatch');
+ * nm.capture(pattern, string[, options]);
+ *
+ * console.log(nm.capture('test/*.js', 'test/foo.js));
+ * //=> ['foo']
+ * console.log(nm.capture('test/*.js', 'foo/bar.css'));
+ * //=> null
+ * ```
+ * @param {String} `pattern` Glob pattern to use for matching.
+ * @param {String} `string` String to match
+ * @param {Object} `options` See available [options](#options) for changing how matches are performed
+ * @return {Boolean} Returns an array of captures if the string matches the glob pattern, otherwise `null`.
+ * @api public
+ */
+
+nanomatch.capture = function(pattern, str, options) {
+  var re = nanomatch.makeRe(pattern, extend({capture: true}, options));
+  var unixify = utils.unixify(options);
+
+  function match() {
+    return function(string) {
+      var match = re.exec(unixify(string));
+      if (!match) {
+        return null;
+      }
+
+      return match.slice(1);
+    };
+  }
+
+  var capture = memoize('capture', pattern, options, match);
+  return capture(str);
+};
+
+/**
  * Create a regular expression from the given glob `pattern`.
  *
  * ```js

--- a/lib/compilers.js
+++ b/lib/compilers.js
@@ -209,6 +209,10 @@ module.exports = function(nanomatch, options) {
         return this.emit('\\/' + val + ')?(?=.)', node);
       }
 
+      if (this.options.capture) {
+        val = '(' + val + ')';
+      }
+
       return this.emit(val, node);
     })
 
@@ -255,7 +259,12 @@ module.exports = function(nanomatch, options) {
         this.output = '(?!\\.)' + this.output;
       }
 
-      return this.emit(prefix + star, node);
+      var output = prefix + star;
+      if (this.options.capture) {
+        output = '(' + output + ')';
+      }
+
+      return this.emit(output, node);
     })
 
     /**
@@ -278,7 +287,7 @@ module.exports = function(nanomatch, options) {
       var prev = this.prev();
       var val = node.val;
       if (this.state.metachar && prev.type !== 'qmark' && prev.type !== 'slash') {
-        val += (this.options.contains ? '\\/?' : '(\\/|$)');
+        val += (this.options.contains ? '\\/?' : '(?:\\/|$)');
       }
 
       return this.emit(val, node);

--- a/test/capture.js
+++ b/test/capture.js
@@ -1,0 +1,26 @@
+var capture = require('../').capture;
+var assert = require('assert');
+
+describe('.capture()', function() {
+  it('should return null if no match', function() {
+    assert.equal(capture('test/*', 'hi/123'), null);
+  });
+
+  it('should return an empty array if there are no captures', function() {
+    assert.deepEqual(capture('test/hi', 'test/hi'), []);
+  });
+
+  it('should capture stars', function() {
+    assert.deepEqual(capture('test/*', 'test/foo'), ['foo']);
+    assert.deepEqual(capture('test/*/bar', 'test/foo/bar'), ['foo']);
+    assert.deepEqual(capture('test/*/bar/*', 'test/foo/bar/baz'), ['foo', 'baz']);
+    assert.deepEqual(capture('test/*.js', 'test/foo.js'), ['foo']);
+    assert.deepEqual(capture('test/*-controller.js', 'test/foo-controller.js'), ['foo']);
+  });
+
+  it('should capture globstars', function() {
+    assert.deepEqual(capture('test/**/*.js', 'test/a.js'), ['', 'a']);
+    assert.deepEqual(capture('test/**/*.js', 'test/dir/a.js'), ['dir', 'a']);
+    assert.deepEqual(capture('test/**/*.js', 'test/dir/test/a.js'), ['dir/test', 'a']);
+  });
+});


### PR DESCRIPTION
This adds a new method `nanomatch.capture`, which returns captured matches from dynamic parts of a pattern (e.g. star, globstar). Should partially address https://github.com/micromatch/micromatch/issues/85.

For example:

```javascript
capture('test/**/*.js', 'test/dir/a.js')
// => ['dir', 'a']
```

This is very useful for a number of purposes. My usecase is building a nested object with results of a glob. For example, given the path and pattern above:

```javascript
{dir: {a: 'test/dir/a.js'}}
```

It works by adding a `capture` option to the compiler, which causes capturing groups to be added to the generated regex for stars and globstars. This option is off by default, so everything continues working exactly the same for other methods.

I couldn't get the documentation generator to run on my system, so if you could run it that would be great. Thanks for a great library!