### PR TITLE
Remove isodd

### DIFF
--- a/lib/parsers.js
+++ b/lib/parsers.js
@@ -93,7 +93,7 @@ module.exports = function(nanomatch, options) {
       if (!m) return;
       var val = m[0];
 
-      var isNegated = ((val.length%2)==1);
+      var isNegated = (val.length % 2) === 1;
       if (parsed === '' && !isNegated) {
         val = '';
       }

--- a/lib/parsers.js
+++ b/lib/parsers.js
@@ -2,7 +2,6 @@
 
 var regexNot = require('regex-not');
 var toRegex = require('to-regex');
-var isOdd = require('is-odd');
 
 /**
  * Characters to use in negation regex (we want to "not" match
@@ -94,7 +93,7 @@ module.exports = function(nanomatch, options) {
       if (!m) return;
       var val = m[0];
 
-      var isNegated = isOdd(val.length);
+      var isNegated = Math.abs(val.length%2)==1;
       if (parsed === '' && !isNegated) {
         val = '';
       }

--- a/lib/parsers.js
+++ b/lib/parsers.js
@@ -93,7 +93,7 @@ module.exports = function(nanomatch, options) {
       if (!m) return;
       var val = m[0];
 
-      var isNegated = Math.abs(val.length%2)==1;
+      var isNegated = ((val.length%2)==1);
       if (parsed === '' && !isNegated) {
         val = '';
       }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "author": "Jon Schlinkert (https://github.com/jonschlinkert)",
   "contributors": [
     "Devon Govett (http://badassjs.com)",
-    "Jon Schlinkert (http://twitter.com/jonschlinkert)"
+    "Jon Schlinkert (http://twitter.com/jonschlinkert)",
+    "Tony Colston (http://twitter.com/tonetheman)"
   ],
   "repository": "micromatch/nanomatch",
   "bugs": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "define-property": "^2.0.2",
     "extend-shallow": "^3.0.2",
     "fragment-cache": "^0.2.1",
-    "is-odd": "^2.0.0",
     "is-windows": "^1.0.2",
     "kind-of": "^6.0.2",
     "object.pick": "^1.3.0",


### PR DESCRIPTION

I removed is-odd from your dependencies. It looked like you used an npm package called is-odd.

It felt like you might not need a package to do that small of a test. No worries if you choose not to take the PR.

After my change I checked that all tests still passed. I did not add any new tests since the change looked like it would be tested during the negate portion of your existing tests.