### PR TITLE
MICROMATCH-140: check for consistency with the end of word

### DIFF
--- a/lib/compilers.js
+++ b/lib/compilers.js
@@ -221,7 +221,7 @@ module.exports = function(nanomatch, options) {
         if (before.type === 'text') {
           this.output += '?';
 
-          if (after.type !== 'text') {
+          if (next.type !== 'text') {
             this.output += '\\b';
           }
         }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "Devon Govett (http://badassjs.com)",
     "Jon Schlinkert (http://twitter.com/jonschlinkert)",
     "Tony Colston (http://twitter.com/tonetheman)",
-    "Daniel Tschinder (https://github.com/danez)"
+    "Daniel Tschinder (https://github.com/danez)",
+    "Denis Malinochkin (https://github.com/mrmlnc)"
   ],
   "repository": "micromatch/nanomatch",
   "bugs": {

--- a/test/globstars.js
+++ b/test/globstars.js
@@ -113,4 +113,10 @@ describe('globstars', function() {
     assert(nm.isMatch('node_modules/foobar/foo.bar', 'node_modules/foobar/**/*.bar'));
     nm(['node_modules/foobar/foo.bar'], 'node_modules/foobar/**/*.bar', ['node_modules/foobar/foo.bar']);
   });
+
+  it('issue micromatch#140', function() {
+    var fixtures = ['a/b/some/c.md', 'a/b/c.md', 'a/bb/c.md', 'a/bbc/c.md'];
+
+    nm(fixtures, '**/b/**/c.md', ['a/b/c.md', 'a/b/some/c.md']);
+  });
 });


### PR DESCRIPTION
## Description

This is not a complete fix for https://github.com/micromatch/micromatch/issues/140.

Now we check that the word ends without additional characters.

## Without this fix

```js
const fixtures = [
  // Correct
  'some/file.md',
  'some/nested/file.md',
  'some_with_magic/file.md',
  'some1/file.md'
];

nm(fixtures, '**/some/**/file.md', ['some/file.md', 'some/nested/file.md', 'some_with_magic/file.md', 'some1/file.md']); // OK
```

## With this fix

```js
const fixtures = [
  // Correct
  'some/file.md',
  'some/nested/file.md',

  // Broken
  'some_with_magic/file.md',
  'some1/file.md'
];

nm(fixtures, '**/some/**/file.md', ['some/file.md', 'some/nested/file.md']); // OK
```

### Bug Fix

- [x] All existing unit tests are still passing (if applicable)
- [x] Add new passing unit tests to cover the code introduced by your pr
- [ ] Update the readme (see [readme advice](#readme-advice))
- [ ] Update or add any necessary API documentation
- [x] Add your info to the [contributors](#packagejson-contributors) array in package.json!