### PR TITLE
`matchingPatterns` method

### DIFF
--- a/README.md
+++ b/README.md
@@ -657,6 +657,28 @@ Clear the regex cache.
 nm.clearCache();
 ```
 
+### [.matchingPatterns](index.js#L105)
+
+Similar to the main function, but returns matched patterns, instead of matched values
+Doesn't work with negative lookup, because it the most cases it doesn't have sense
+
+**Params**
+
+* `list` **{Array}**: A list of strings to match
+* `patterns` **{String|Array}**: One or more glob patterns to use for matching
+* `options` **{Object}**: See available [options](#options) for changing how matches are performed
+* `returns` **{Array}**: Returns an array of metched patterns
+
+**Example**
+
+```js
+var nm = require('nanomatch');
+nm.matchingPatterns(list, pattern[, options]);
+
+console.log(nm.matchingPatterns(['a.a', 'a.aa', 'a.b', 'a.c'], ['*.a', '*.d']));
+//=> ['*.a']
+```
+
 ## Options
 
 <details>

--- a/index.js
+++ b/index.js
@@ -110,39 +110,19 @@ nanomatch.matchingPatterns = function(list, patterns, options) {
     return [];
   }
 
-  let negated = false;
   const omit = [];
   const keep = [];
   let idx = -1;
 
   while (++idx < len) {
     const pattern = patterns[idx];
+    const match = nanomatch.match(list, pattern, options);
 
-    if (typeof pattern === 'string' && pattern.charCodeAt(0) === 33 /* ! */) {
-      const match = nanomatch.match(list, pattern, options);
-
-      match.length > 0 && omit.push(pattern);
-      negated = true;
-    } else {
-      const match = nanomatch.match(list, pattern, options);
-
-      match.length > 0 && keep.push(pattern);
-    }
-  }
-
-  // minimatch.match parity
-  if (negated && keep.length === 0) {
-    if (options && options.unixify === false) {
-      keep = list.slice();
-    } else {
-      const unixify = utils.unixify(options);
-      for (var i = 0; i < list.length; i++) {
-        keep.push(unixify(list[i]));
-      }
-    }
+    match.length > 0 && keep.push(pattern);
   }
 
   const matches = utils.diff(keep, omit);
+
   if (!options || options.nodupes !== false) {
     return utils.unique(matches);
   }

--- a/index.js
+++ b/index.js
@@ -87,6 +87,7 @@ function nanomatch(list, patterns, options) {
 
 /**
  * Similar to the main function, but returns matched patterns, instead of matched values
+ * Doesn't work with negative lookup, because it the most cases it doesn't have sense
  *
  * ```js
  * const nm = require('nanomatch');
@@ -96,7 +97,7 @@ function nanomatch(list, patterns, options) {
  * //=> ['*.a']
  * ```
  * @param {Array} `list` Array of strings to match
- * @param {String} `pattern` Glob pattern to use for matching.
+ * @param {Array} `pattern` Array of patterns
  * @param {Object} `options` See available [options](#options) for changing how matches are performed
  * @return {Array} Returns an array of matched patterns
  * @api public

--- a/index.js
+++ b/index.js
@@ -86,6 +86,25 @@ function nanomatch(list, patterns, options) {
 }
 
 /**
+ * Similar to the main function, but returns matched patterns, instead of matched values
+ *
+ * ```js
+ * const nm = require('nanomatch');
+ * nm.matchingPatterns(list, pattern[, options]);
+ *
+ * console.log(nm.matchingPatterns(['a.a', 'a.aa', 'a.b', 'a.c'], ['*.a', '*.d']));
+ * //=> ['*.a']
+ * ```
+ * @param {Array} `list` Array of strings to match
+ * @param {String} `pattern` Glob pattern to use for matching.
+ * @param {Object} `options` See available [options](#options) for changing how matches are performed
+ * @return {Array} Returns an array of matched patterns
+ * @api public
+ */
+nanomatch.matchingPatterns = function(list, pattern, options) {
+}
+
+/**
  * Similar to the main function, but `pattern` must be a string.
  *
  * ```js

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "Devon Govett (http://badassjs.com)",
     "Jon Schlinkert (http://twitter.com/jonschlinkert)",
     "Tony Colston (http://twitter.com/tonetheman)",
-    "Daniel Tschinder (https://github.com/danez)"
+    "Daniel Tschinder (https://github.com/danez)",
+    "Konstantin Epishev (https://epishev.me)"
   ],
   "repository": "micromatch/nanomatch",
   "bugs": {

--- a/test/api.mathchingPatterns.js
+++ b/test/api.mathchingPatterns.js
@@ -1,17 +1,15 @@
 'use strict';
 
-var path = require('path');
 var assert = require('assert');
-var sep = path.sep;
 var nm = require('./support/match');
 
 describe('.matchingPatterns method', function() {
   describe('posix paths', function() {
     it('should return an array of matched patterns for a literal string', function() {
-      assert.deepEqual(nm.matchingPatterns(['a/a', 'a/b', 'a/c', 'b/a', 'b/b', 'b/c'], '(a/b)'), ['a/b']);
-      assert.deepEqual(nm.matchingPatterns(['a/a', 'a/b', 'a/c', 'b/a', 'b/b', 'b/c'], 'a/b'), ['a/b']);
-      assert.deepEqual(nm.matchingPatterns(['a/a', 'a/b', 'a/c', 'b/a', 'b/b', 'b/c'], '(a/d)'), []);
-      assert.deepEqual(nm.matchingPatterns(['a/a', 'a/b', 'a/c', 'b/a', 'b/b', 'b/c'], 'a/d'), []);
+      assert.deepEqual(nm.matchingPatterns(['a/a', 'a/b', 'a/c', 'b/a', 'b/b', 'b/c'], ['(a/b)']), ['(a/b)']);
+      assert.deepEqual(nm.matchingPatterns(['a/a', 'a/b', 'a/c', 'b/a', 'b/b', 'b/c'], ['a/b']), ['a/b']);
+      assert.deepEqual(nm.matchingPatterns(['a/a', 'a/b', 'a/c', 'b/a', 'b/b', 'b/c'], ['(a/d)']), []);
+      assert.deepEqual(nm.matchingPatterns(['a/a', 'a/b', 'a/c', 'b/a', 'b/b', 'b/c'], ['a/d']), []);
     });
   });
 });

--- a/test/api.mathchingPatterns.js
+++ b/test/api.mathchingPatterns.js
@@ -1,0 +1,17 @@
+'use strict';
+
+var path = require('path');
+var assert = require('assert');
+var sep = path.sep;
+var nm = require('./support/match');
+
+describe('.matchingPatterns method', function() {
+  describe('posix paths', function() {
+    it('should return an array of matched patterns for a literal string', function() {
+      assert.deepEqual(nm.matchingPatterns(['a/a', 'a/b', 'a/c', 'b/a', 'b/b', 'b/c'], '(a/b)'), ['a/b']);
+      assert.deepEqual(nm.matchingPatterns(['a/a', 'a/b', 'a/c', 'b/a', 'b/b', 'b/c'], 'a/b'), ['a/b']);
+      assert.deepEqual(nm.matchingPatterns(['a/a', 'a/b', 'a/c', 'b/a', 'b/b', 'b/c'], '(a/d)'), []);
+      assert.deepEqual(nm.matchingPatterns(['a/a', 'a/b', 'a/c', 'b/a', 'b/b', 'b/c'], 'a/d'), []);
+    });
+  });
+});

--- a/test/api.mathchingPatterns.js
+++ b/test/api.mathchingPatterns.js
@@ -1,7 +1,9 @@
 'use strict';
 
 var assert = require('assert');
+var path = require('path');
 var nm = require('./support/match');
+var sep = path.sep;
 
 describe('.matchingPatterns method', function() {
   describe('posix paths', function() {
@@ -10,6 +12,158 @@ describe('.matchingPatterns method', function() {
       assert.deepEqual(nm.matchingPatterns(['a/a', 'a/b', 'a/c', 'b/a', 'b/b', 'b/c'], ['a/b']), ['a/b']);
       assert.deepEqual(nm.matchingPatterns(['a/a', 'a/b', 'a/c', 'b/a', 'b/b', 'b/c'], ['(a/d)']), []);
       assert.deepEqual(nm.matchingPatterns(['a/a', 'a/b', 'a/c', 'b/a', 'b/b', 'b/c'], ['a/d']), []);
+    });
+
+    it('should return an array of matches for an array of literal strings', function() {
+      assert.deepEqual(nm.matchingPatterns(['a/a', 'a/b', 'a/c', 'b/a', 'b/b', 'b/c'], ['(a/b)', 'a/c']), ['(a/b)', 'a/c']);
+      assert.deepEqual(nm.matchingPatterns(['a/a', 'a/b', 'a/c', 'b/a'], ['a/b']), ['a/b']);
+    });
+
+    it('should support regex logical or', function() {
+      assert.deepEqual(nm.matchingPatterns(['a/a', 'a/b', 'a/c'], ['a/(a|c)']), ['a/(a|c)']);
+      assert.deepEqual(nm.matchingPatterns(['a/a', 'a/b', 'a/c'], ['a/(a|b|c)', 'a/b']), ['a/(a|b|c)', 'a/b']);
+    });
+
+    it('should support regex ranges', function() {
+      assert.deepEqual(nm.matchingPatterns(['a/a', 'a/b', 'a/c'], ['a/[b-c]']), ['a/[b-c]']);
+      assert.deepEqual(nm.matchingPatterns(['a/a', 'a/b', 'a/c', 'a/x/y', 'a/x'], ['a/[a-z]']), ['a/[a-z]']);
+    });
+
+    it('should support single globs (*)', function() {
+      var fixtures = ['a', 'b', 'a/a', 'a/b', 'a/c', 'a/x', 'a/a/a', 'a/a/b', 'a/a/a/a', 'a/a/a/a/a', 'x/y', 'z/z'];
+      assert.deepEqual(nm.matchingPatterns(fixtures, ['*']), ['*']);
+      assert.deepEqual(nm.matchingPatterns(fixtures, ['*/*']), ['*/*']);
+      assert.deepEqual(nm.matchingPatterns(fixtures, ['*/*/*']), ['*/*/*']);
+      assert.deepEqual(nm.matchingPatterns(fixtures, ['*/*/*/*']), ['*/*/*/*']);
+      assert.deepEqual(nm.matchingPatterns(fixtures, ['*/*/*/*/*']), ['*/*/*/*/*']);
+      assert.deepEqual(nm.matchingPatterns(fixtures, ['a/*']), ['a/*']);
+      assert.deepEqual(nm.matchingPatterns(fixtures, ['a/*/*']), ['a/*/*']);
+      assert.deepEqual(nm.matchingPatterns(fixtures, ['a/*/*/*']), ['a/*/*/*']);
+      assert.deepEqual(nm.matchingPatterns(fixtures, ['a/*/*/*/*']), ['a/*/*/*/*']);
+      assert.deepEqual(nm.matchingPatterns(fixtures, ['a/*/a']), ['a/*/a']);
+      assert.deepEqual(nm.matchingPatterns(fixtures, ['a/*/b']), ['a/*/b']);
+    });
+
+    it('should support globstars (**)', function() {
+      var fixtures = ['a', 'a/', 'a/a', 'a/b', 'a/c', 'a/x', 'a/x/y', 'a/x/y/z'];
+      assert.deepEqual(nm.matchingPatterns(fixtures, ['*']), ['*']);
+      assert.deepEqual(nm.matchingPatterns(fixtures, ['*/']), ['*/']);
+      assert.deepEqual(nm.matchingPatterns(fixtures, ['*/*']), ['*/*']);
+      assert.deepEqual(nm.matchingPatterns(fixtures, ['**']), ['**']);
+      assert.deepEqual(nm.matchingPatterns(fixtures, ['**/a']), ['**/a']);
+      assert.deepEqual(nm.matchingPatterns(fixtures, ['a/*']), ['a/*']);
+      assert.deepEqual(nm.matchingPatterns(fixtures, ['a/**']), ['a/**']);
+      assert.deepEqual(nm.matchingPatterns(fixtures, ['a/**/*']), ['a/**/*']);
+      assert.deepEqual(nm.matchingPatterns(fixtures, ['a/**/**/*']), ['a/**/**/*']);
+      assert.deepEqual(nm.matchingPatterns(['a/b/foo/bar/baz.qux'], ['a/b/**/bar/**/*.*']), ['a/b/**/bar/**/*.*']);
+      assert.deepEqual(nm.matchingPatterns(['a/b/bar/baz.qux'], ['a/b/**/bar/**/*.*']), ['a/b/**/bar/**/*.*']);
+    });
+
+    it('should work with file extensions', function() {
+      var fixtures = ['a.txt', 'a/b.txt', 'a/x/y.txt', 'a/x/y/z'];
+      assert.deepEqual(nm.matchingPatterns(fixtures, ['a/**/*.txt']), ['a/**/*.txt']);
+      assert.deepEqual(nm.matchingPatterns(fixtures, ['a/*.txt']), ['a/*.txt']);
+      assert.deepEqual(nm.matchingPatterns(fixtures, ['a*.txt']), ['a*.txt']);
+      assert.deepEqual(nm.matchingPatterns(fixtures, ['*.txt']), ['*.txt']);
+    });
+
+    it('should match literal brackets', function() {
+      assert.deepEqual(nm.matchingPatterns(['a [b]'], ['a \\[b\\]']), ['a \\[b\\]']);
+      assert.deepEqual(nm.matchingPatterns(['a [b] c'], ['a [b] c']), ['a [b] c']);
+      assert.deepEqual(nm.matchingPatterns(['a [b]'], ['a \\[b\\]*']), ['a \\[b\\]*']);
+      assert.deepEqual(nm.matchingPatterns(['a [bc]'], ['a \\[bc\\]*']), ['a \\[bc\\]*']);
+      assert.deepEqual(nm.matchingPatterns(['a [b]', 'a [b].js'], ['a \\[b\\].*']), ['a \\[b\\].*']);
+    });
+
+    describe('windows paths', function() {
+      beforeEach(function() {
+        path.sep = '\\';
+      });
+      afterEach(function() {
+        path.sep = sep;
+      });
+
+      it('should return an array of matches for a literal string', function() {
+        var fixtures = ['a\\a', 'a\\b', 'a\\c', 'b\\a', 'b\\b', 'b\\c'];
+        assert.deepEqual(nm.matchingPatterns(fixtures, ['(a/b)']), ['(a/b)']);
+        assert.deepEqual(nm.matchingPatterns(fixtures, ['a/b']), ['a/b']);
+        assert.deepEqual(nm.matchingPatterns(fixtures, ['(a/b)']), ['(a/b)']);
+        assert.deepEqual(nm.matchingPatterns(fixtures, ['a/b']), ['a/b']);
+      });
+
+      it('should return an array of matches for an array of literal strings', function() {
+        var fixtures = ['a\\a', 'a\\b', 'a\\c', 'b\\a', 'b\\b', 'b\\c'];
+        assert.deepEqual(nm.matchingPatterns(fixtures, ['(a/b)', 'a/c']), ['(a/b)', 'a/c']);
+        assert.deepEqual(nm.matchingPatterns(fixtures, ['a/b', 'b/b']), ['a/b', 'b/b']);
+        assert.deepEqual(nm.matchingPatterns(fixtures, ['(a/b)', 'a/c']), ['(a/b)', 'a/c']);
+        assert.deepEqual(nm.matchingPatterns(fixtures, ['a/b', 'b/b']), ['a/b', 'b/b']);
+      });
+
+      it('should support regex logical or', function() {
+        var fixtures = ['a\\a', 'a\\b', 'a\\c'];
+        assert.deepEqual(nm.matchingPatterns(fixtures, ['a/(a|c)']), ['a/(a|c)']);
+        assert.deepEqual(nm.matchingPatterns(fixtures, ['a/(a|b|c)', 'a/b']), ['a/(a|b|c)', 'a/b']);
+        assert.deepEqual(nm.matchingPatterns(fixtures, ['a/(a|c)']), ['a/(a|c)']);
+        assert.deepEqual(nm.matchingPatterns(fixtures, ['a/(a|b|c)', 'a/b']), ['a/(a|b|c)', 'a/b']);
+      });
+
+      it('should support regex ranges', function() {
+        var fixtures = ['a\\a', 'a\\b', 'a\\c', 'a\\x\\y', 'a\\x'];
+        assert.deepEqual(nm.matchingPatterns(fixtures, ['a/[b-c]']), ['a/[b-c]']);
+        assert.deepEqual(nm.matchingPatterns(fixtures, ['a/[a-z]']), ['a/[a-z]']);
+        assert.deepEqual(nm.matchingPatterns(fixtures, ['a/[b-c]']), ['a/[b-c]']);
+        assert.deepEqual(nm.matchingPatterns(fixtures, ['a/[a-z]']), ['a/[a-z]']);
+      });
+
+      it('should support single globs (*)', function() {
+        var fixtures = ['a', 'b', 'a\\a', 'a\\b', 'a\\c', 'a\\x', 'a\\a\\a', 'a\\a\\b', 'a\\a\\a\\a', 'a\\a\\a\\a\\a', 'x\\y', 'z\\z'];
+        assert.deepEqual(nm.matchingPatterns(fixtures, ['*']), ['*']);
+        assert.deepEqual(nm.matchingPatterns(fixtures, ['*/*']), ['*/*']);
+        assert.deepEqual(nm.matchingPatterns(fixtures, ['*/*/*']), ['*/*/*']);
+        assert.deepEqual(nm.matchingPatterns(fixtures, ['*/*/*/*']), ['*/*/*/*']);
+        assert.deepEqual(nm.matchingPatterns(fixtures, ['*/*/*/*/*']), ['*/*/*/*/*']);
+        assert.deepEqual(nm.matchingPatterns(fixtures, ['a/*']), ['a/*']);
+        assert.deepEqual(nm.matchingPatterns(fixtures, ['a/*/*']), ['a/*/*']);
+        assert.deepEqual(nm.matchingPatterns(fixtures, ['a/*/*/*']), ['a/*/*/*']);
+        assert.deepEqual(nm.matchingPatterns(fixtures, ['a/*/*/*/*']), ['a/*/*/*/*']);
+        assert.deepEqual(nm.matchingPatterns(fixtures, ['a/*/a']), ['a/*/a']);
+        assert.deepEqual(nm.matchingPatterns(fixtures, ['a/*/b']), ['a/*/b']);
+
+        assert.deepEqual(nm.matchingPatterns(fixtures, ['*/*']), ['*/*']);
+        assert.deepEqual(nm.matchingPatterns(fixtures, ['*/*/*']), ['*/*/*']);
+        assert.deepEqual(nm.matchingPatterns(fixtures, ['*/*/*/*']), ['*/*/*/*']);
+        assert.deepEqual(nm.matchingPatterns(fixtures, ['*/*/*/*/*']), ['*/*/*/*/*']);
+        assert.deepEqual(nm.matchingPatterns(fixtures, ['a/*']), ['a/*']);
+        assert.deepEqual(nm.matchingPatterns(fixtures, ['a/*/*']), ['a/*/*']);
+        assert.deepEqual(nm.matchingPatterns(fixtures, ['a/*/*/*']), ['a/*/*/*']);
+        assert.deepEqual(nm.matchingPatterns(fixtures, ['a/*/*/*/*']), ['a/*/*/*/*']);
+        assert.deepEqual(nm.matchingPatterns(fixtures, ['a/*/a']), ['a/*/a']);
+        assert.deepEqual(nm.matchingPatterns(fixtures, ['a/*/b']), ['a/*/b']);
+      });
+
+      it('should support globstars (**)', function() {
+        var fixtures = ['a\\a', 'a\\b', 'a\\c', 'a\\x', 'a\\x\\y', 'a\\x\\y\\z'];
+        var expected = ['a/a', 'a/b', 'a/c', 'a/x', 'a/x/y', 'a/x/y/z'];
+        assert.deepEqual(nm.matchingPatterns(fixtures, ['a/**']), ['a/**']);
+        assert.deepEqual(nm.matchingPatterns(fixtures, ['a/**/*']), ['a/**/*']);
+        assert.deepEqual(nm.matchingPatterns(fixtures, ['a/**/**/*']), ['a/**/**/*']);
+
+        assert.deepEqual(nm.matchingPatterns(fixtures, ['a/**']), ['a/**']);
+        assert.deepEqual(nm.matchingPatterns(fixtures, ['a/**/*']), ['a/**/*']);
+        assert.deepEqual(nm.matchingPatterns(fixtures, ['a/**/**/*']), ['a/**/**/*']);
+      });
+
+      it('should work with file extensions', function() {
+        var fixtures = ['a.txt', 'a\\b.txt', 'a\\x\\y.txt', 'a\\x\\y\\z'];
+        assert.deepEqual(nm.matchingPatterns(fixtures, ['a/**/*.txt']), ['a/**/*.txt']);
+        assert.deepEqual(nm.matchingPatterns(fixtures, ['a/*/*.txt']), ['a/*/*.txt']);
+        assert.deepEqual(nm.matchingPatterns(fixtures, ['a/*.txt']), ['a/*.txt']);
+        assert.deepEqual(nm.matchingPatterns(fixtures, ['a/**/*.txt']), ['a/**/*.txt']);
+        assert.deepEqual(nm.matchingPatterns(fixtures, ['a/*/*.txt']), ['a/*/*.txt']);
+        assert.deepEqual(nm.matchingPatterns(fixtures, ['a/*.txt']), ['a/*.txt']);
+        assert.deepEqual(nm.matchingPatterns(fixtures, ['a*.txt']), ['a*.txt']);
+        assert.deepEqual(nm.matchingPatterns(fixtures, ['a.txt']), ['a.txt']);
+      });
     });
   });
 });


### PR DESCRIPTION
## Description

This PR adds `.matchingPatterns` methods, which returns matched patterns. It's very useful, when you need to determine required patterns by given strings and then use them.

To help the project's maintainers and community to quickly understand the nature of your pull requeset, please create a description that incorporates the following elements:

This PR doesn't contain any breaking changes.

I didn't add support for negative lookup, because I can't imaging use-cases for them. But, if you think, that them also should be implemented – let me know.

### New Feature

- [x] If this is a big feature with breaking changes, consider [opening an issue][issues] to discuss first. This is completely up to you, but please keep in mind that your pr might not be accepted.
- [x] Run unit tests to ensure all existing tests are still passing
- [x] Add new passing unit tests to cover the code introduced by your pr
- [x] Update the readme (see [readme advice](#readme-advice))
- [x] Add your info to the [contributors](#packagejson-contributors) array in package.json!

[issues]: ../../issues
[verb]: https://github.com/verbose/verb
